### PR TITLE
Optional chaining on createMachineMeta

### DIFF
--- a/packages/spellbook/package.json
+++ b/packages/spellbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xstate-wizards/spellbook",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "author": "Mark Hansen",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -17,8 +17,8 @@
     "yalclink": "npx yalc link @xstate-wizards/spells && npx yalc link @xstate-wizards/wizards-of-react"
   },
   "dependencies": {
-    "@xstate-wizards/spells": "^0.8.6",
-    "@xstate-wizards/wizards-of-react": "^0.6.11",
+    "@xstate-wizards/spells": "^0.8.7",
+    "@xstate-wizards/wizards-of-react": "^0.6.12",
     "date-fns": "^2.4.1",
     "framer-motion": "^6.4.3",
     "lodash": "^4.17.20",

--- a/packages/spells/package.json
+++ b/packages/spells/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xstate-wizards/spells",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "author": "Mark Hansen",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/spells/src/machines/createSpell.ts
+++ b/packages/spells/src/machines/createSpell.ts
@@ -48,8 +48,8 @@ export const createSpell = ({
         // ... first, use the spell config as meta
         ...config,
         // ... second, merge any machine meta passed in via createMachine (gives exitTo/initial)
-        initial: createMachineMeta.initial ?? config.initial,
-        exitTo: createMachineMeta.exitTo ?? config.exitTo,
+        initial: createMachineMeta?.initial ?? config?.initial,
+        exitTo: createMachineMeta?.exitTo ?? config?.exitTo,
         // ... lastly, setup our session
         ...setupMetaSession(session),
       };

--- a/packages/wizards-of-react/package.json
+++ b/packages/wizards-of-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xstate-wizards/wizards-of-react",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "author": "Mark Hansen",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
     "yalclink": "npx yalc link @xstate-wizards/spells"
   },
   "dependencies": {
-    "@xstate-wizards/spells": "^0.8.6",
+    "@xstate-wizards/spells": "^0.8.7",
     "@xstate/react": "1.3.4",
     "date-fns": "^2.4.1",
     "lodash": "^4.17.20",


### PR DESCRIPTION
createMachine may not provide a meta obj, causing an error trying to access an initial property